### PR TITLE
Fix issue with rand type generation

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -75,7 +75,7 @@ def _get_rand_type(field_type: Union[str, Type[T]]) -> T:
     :return: random field value
     """
     if isinstance(field_type, str):
-        field_type = getattr(models, field_type)
+        field_type = eval(field_type, vars(models))
 
     if field_type in TYPE_TO_ACTION:
         return TYPE_TO_ACTION[field_type]()


### PR DESCRIPTION
Python type annotations can be defined as strings.
```py
class User:
     name: "str"

asser User.__annotations__ == {"name": "str"}
```
In case when `from __future__ import annotations` is used, all annotations will be automatically converted to strings. For more information - [PEP 563](https://www.python.org/dev/peps/pep-0563/).
```py
from __future__ import annotations

class User:
    name: str

asser User.__annotations__ == {"name": "str"}
```

Since python `3.10` `from __future__ import annotations` mode is enabled by default.

This PR will fix the issue when `_get_rand_type` can't generate a type for a built-in type defined as strings.
